### PR TITLE
resize content when exiting from fullscreen

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -66,6 +66,7 @@
 
     self.on('exitFullScreen', function () {
       self.$container.css('height', self.options.timeline.height + 'px');
+      $(window).trigger('resize');
     });
   };
 


### PR DESCRIPTION
When exiting from fullscreen, the content was not resized properly (when embedded elsewhere).